### PR TITLE
Create CODEOWNERS

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -2,21 +2,21 @@
 # the repo. Unless a later match takes precedence,
 # @<global-owner> will be requested for
 # review when someone opens a pull request.
-*         @thecloudexplorers/sovereign-solutions
+*                @thecloudexplorers/sovereign-solutions
 
 # In this example, @thecloudexplorers/sovereign-solutions-reviewers
 # owns any files in the src/nix directory at the root of the repository
 # and any of its subdirectories.
-/src/nix/  @thecloudexplorers/sovereign-solutions-reviewers
+/src/nix/        @thecloudexplorers/tcs-nix-reviewers
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies PowerShell files, only this owner and not the global
 # owner(s) will be requested for a review.
-*.ps1      @devjevnl
+/src/powershell/  @thecloudexplorers/tce-powershell-reviewers
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies Azure Pipelines files, only this owner and not the
 # global owner(s) will be requested for a review.
-*.yml      @devjevnl
+*.yml            @thecloudexplorers/tcs-azure-pipelines-reviewers

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -7,7 +7,7 @@
 # In this example, @thecloudexplorers/sovereign-solutions-reviewers
 # owns any files in the src/nix directory at the root of the repository
 # and any of its subdirectories.
-/src/nix/        @thecloudexplorers/tcs-nix-reviewers
+/src/nix/        @thecloudexplorers/tce-nix-reviewers
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,22 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @<global-owner> will be requested for
+# review when someone opens a pull request.
+*         @thecloudexplorers/sovereign-solutions
+
+# In this example, @thecloudexplorers/sovereign-solutions-reviewers
+# owns any files in the src/nix directory at the root of the repository
+# and any of its subdirectories.
+/src/nix/  @thecloudexplorers/sovereign-solutions-reviewers
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies PowerShell files, only this owner and not the global
+# owner(s) will be requested for a review.
+*.ps1      @devjevnl
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies Azure Pipelines files, only this owner and not the
+# global owner(s) will be requested for a review.
+*.yml      @devjevnl

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -19,4 +19,4 @@
 # precedence. When someone opens a pull request that only
 # modifies Azure Pipelines files, only this owner and not the
 # global owner(s) will be requested for a review.
-*.yml            @thecloudexplorers/tcs-azure-pipelines-reviewers
+*.yml            @thecloudexplorers/tce-azure-pipelines-reviewers


### PR DESCRIPTION
Ensure code owners are set and result in proper allocation of code owners.

Needs to be refined with further/specific code owners in next iteration.